### PR TITLE
Fix possible NaN values in Supervised Contrastive Loss

### DIFF
--- a/core/loss/SupervisedContrastiveLoss.py
+++ b/core/loss/SupervisedContrastiveLoss.py
@@ -13,7 +13,6 @@ class SupConLoss(nn.Module):
 
     def forward(self, embeddings, labels):
         n = labels.shape[0]  # batch
-        # similarity_matrix = torch.matmul(features, features.T)
         similarity_matrix = F.cosine_similarity(embeddings.unsqueeze(1), embeddings.unsqueeze(0), dim=2)
 
         mask = torch.ones_like(similarity_matrix) * (labels.expand(n, n).eq(labels.expand(n, n).t()))
@@ -29,13 +28,11 @@ class SupConLoss(nn.Module):
 
         no_sim_sum = torch.sum(no_sim, dim=1)
         no_sim_sum_expend = no_sim_sum.repeat(n, 1).T
-        sim_sum = sim + no_sim_sum_expend
+        epsilon = 1e-8
+        sim_sum = sim + no_sim_sum_expend + epsilon
 
         loss_partial = -torch.log(mask_no_sim + torch.div(sim, sim_sum) + torch.eye(n, n).to(self.device))
 
         loss = torch.sum(torch.sum(loss_partial, dim=1)) / (len(torch.nonzero(loss_partial)))
 
         return loss
-
-
-


### PR DESCRIPTION
In `SupervisedContrastiveLoss.py`, when the `sim_sum` tensor contains zero values, `torch.div(sim, sim_sum)` results in NaN values, causing the entire loss computation to produce NaN. This issue occurred for me multiple times during the calculation of the Task-Oriented Learning loss, making the whole training process unstable.

I have added a small epsilon (`1e-8`) to all denominators to prevent NaN or infinite values caused by division by zero.